### PR TITLE
Fix typo in run command

### DIFF
--- a/docs/users/how-to-install-if.md
+++ b/docs/users/how-to-install-if.md
@@ -44,7 +44,7 @@ npm install
 Then, use the following command to run Impact Framework:
 
 ```sh
-npm run if -- --manifest <path to your manifest file>
+npm run ie -- --manifest <path to your manifest file>
 ```
 
 Next, install local plugin repositories using `npm link`. You can do this by entering the plugin folder and running the following command:


### PR DESCRIPTION
Looks like the correct command is "ie", as seen in package.json as well. Fixing the typo :)