### PR TITLE
Update Edit button in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           // Change this to your repo.
-          editUrl: "https://github.com/Green-Software-Foundation/ief/",
+          editUrl: "https://github.com/Green-Software-Foundation/if-docs/edit/master",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Since docs moved to another repo, the "edit this page" button started to fail. I validated this change by running "yarn docusaurus start" and pressing on some "edit this page" buttons on pages. This is all I expect to change with this PR, but I am not familiar with Docusaurus to prove it for certain. :)