### PR TITLE
add link to awards ceremony

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -16,7 +16,7 @@ Carbon Hack is a dynamic competition that combines healthy rivalry with collabor
 CarbonHack is open to all, including software practitioners and those with a passion for Green Software.
 Find out more about CarbonHack 2024 on the [CarbonHack website](https://grnsft.org/hack/github)
 
-**Attend the the [Closing & Award Ceremony Livestream](https://hack.greensoftware.foundation/awards/) on April 18th!**
+**Attend the [Closing & Award Ceremony Livestream](https://hack.greensoftware.foundation/awards/) on April 18th!**
 
 ----------------------------
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -16,7 +16,7 @@ Carbon Hack is a dynamic competition that combines healthy rivalry with collabor
 CarbonHack is open to all, including software practitioners and those with a passion for Green Software.
 Find out more about CarbonHack 2024 on the [CarbonHack website](https://grnsft.org/hack/github)
 
-**Registration opens 22nd January!**
+**Attend the the [Closing & Award Ceremony Livestream](https://hack.greensoftware.foundation/awards/) on April 18th!**
 
 ----------------------------
 


### PR DESCRIPTION
Adds CTA and link about the hackathon awards ceremony

Partially fixes https://github.com/Green-Software-Foundation/carbonhack-event/issues/349