### PR TITLE
:memo: Fix example in quick-start.md

### DIFF
--- a/docs/users/quick-start.md
+++ b/docs/users/quick-start.md
@@ -33,7 +33,7 @@ initialize:
       path: 'builtin'
       method: Coefficient
       config:
-        input-parameter: "cpu-utilization"
+        input-parameter: "cpu/utilization"
         coefficient: 2
         output-parameter: "cpu-utilization-doubled"
 


### PR DESCRIPTION
In Quick Start, we should create a manifest with a wrong key.
In yml file, the `input-parameter` parameter in config must be `"cpu/utilization"` and not with a `-`