### PR TITLE
Update quick-start.md

### DIFF
--- a/docs/users/quick-start.md
+++ b/docs/users/quick-start.md
@@ -33,7 +33,7 @@ initialize:
       path: 'builtin'
       method: Coefficient
       config:
-        input-parameter: "cpu-utilization"
+        input-parameter: "cpu/utilization"
         coefficient: 2
         output-parameter: "cpu-utilization-doubled"
 


### PR DESCRIPTION
"cpu-utilization" is incorrect, and causing execution of the manifest file to fail. Updating it to "cpu/utilization" fixes the execution error.